### PR TITLE
Fix exploiter under AsyncVectorEnv (E20 crash)

### DIFF
--- a/rl/exploiter.py
+++ b/rl/exploiter.py
@@ -30,60 +30,32 @@ from __future__ import annotations
 
 import argparse
 
-import torch
-
-from rl.engine import NUM_ACTIONS
-from rl.opponents import (
-    OpponentPool,
-    make_frozen_recurrent_opponent_factory,
-)
-from rl.policy import load_recurrent_policy
 from rl.ppo_recurrent import RecurrentPPOConfig, train as ppo_recurrent_train
-
-
-def make_exploiter_pool_factory(opponent_ckpt: str, device: str = "cpu"):
-    """Return a callable that builds a fresh exploiter-only pool.
-
-    The pool contains ONLY the frozen main (under the name 'main').
-    Exploiter snapshots will be added during training by the standard
-    ppo_recurrent snapshot block, giving a small self-play loop
-    (exploiter vs main + recent exploiter selves) that keeps the
-    exploiter from collapsing to a single brittle counter.
-    """
-    frozen = load_recurrent_policy(opponent_ckpt, n_actions=NUM_ACTIONS, device=device)
-    frozen.eval()
-    for param in frozen.parameters():
-        param.requires_grad_(False)
-    main_factory = make_frozen_recurrent_opponent_factory(frozen, device=device)
-    # Annotate so pool.manifest() can round-trip into async workers.
-    main_factory.ckpt_path = opponent_ckpt  # type: ignore[attr-defined]
-    return frozen, main_factory
 
 
 def train_exploiter(opponent_ckpt: str, cfg: RecurrentPPOConfig):
     """Train a recurrent exploiter whose only fixed opponent is
-    `opponent_ckpt`. Monkey-patches OpponentPool inside ppo_recurrent
-    so the existing training loop picks up the exploiter-only pool
-    without other code changes.
+    `opponent_ckpt`.
+
+    Rides the standard `ppo_recurrent.train` flow with two knobs:
+      * `extra_opponent_ckpts=[opponent_ckpt]` — loads the frozen target
+        into the pool with a `.ckpt_path` annotation that survives the
+        AsyncVectorEnv spawn-pickle via manifest broadcast.
+      * `cfg.exclude_rule_based = True` — drops NAMED_OPPONENTS from the
+        parent pool after extras are loaded, so training samples ONLY
+        the target (plus future exploiter snapshots). The worker seed
+        pool still carries NAMED_OPPONENTS briefly for spawn-safe env
+        init, but sync_pool replaces it before the first real rollout.
+
+    Historical note: an earlier version monkey-patched OpponentPool to
+    inject a CUDA factory at the class level. That worked under
+    SyncVectorEnv but broke under AsyncVectorEnv (CUDA tensor pickled
+    through the spawn pipe → BrokenPipeError). The flag-based approach
+    keeps all CUDA refs in the parent process and ships ckpt paths to
+    workers for CPU-side reload.
     """
-    import rl.ppo_recurrent as ppo_mod
-
-    _, main_factory = make_exploiter_pool_factory(opponent_ckpt, device=cfg.device)
-
-    class _ExploiterPoolClass(OpponentPool):
-        def __init__(self, base_opponents=None):
-            # Ignore rule-based opponents entirely. Snapshot-add during
-            # training still appends exploiter selves to the pool.
-            super().__init__({"main": main_factory})
-
-    original = ppo_mod.OpponentPool
-    try:
-        ppo_mod.OpponentPool = _ExploiterPoolClass
-        policy = ppo_recurrent_train(cfg)
-    finally:
-        ppo_mod.OpponentPool = original
-
-    return policy
+    cfg.exclude_rule_based = True
+    return ppo_recurrent_train(cfg, extra_opponent_ckpts=[opponent_ckpt])
 
 
 def parse_args() -> argparse.Namespace:

--- a/rl/ppo_recurrent.py
+++ b/rl/ppo_recurrent.py
@@ -91,6 +91,12 @@ class RecurrentPPOConfig:
     # id into the embedding so the trunk can condition on opponent
     # identity. Set to N_OPPONENT_IDS (5) to match the env's ID table.
     n_opponents: int = 0
+    # Exploiter training: if True, drop NAMED_OPPONENTS from the parent pool
+    # after `extra_opponent_ckpts` load, so the agent trains ONLY vs the
+    # extras (typically one frozen target) instead of a mixed league. The
+    # worker seed pool keeps NAMED_OPPONENTS for spawn-safe init; the
+    # first post-sync rollout samples exclusively from extras.
+    exclude_rule_based: bool = False
     save_dir: str = "rl_runs"
     run_name: str = field(default_factory=lambda: f"ppo_recurrent_{int(time.time())}")
 
@@ -215,6 +221,23 @@ def train(
                     print(f"[train] added FEEDFORWARD extra opponent {label} from {path}")
             except Exception as exc:
                 print(f"[train] WARNING: could not load extra opponent {path}: {exc}")
+
+    if cfg.exclude_rule_based:
+        # Exploiter mode: after extras are loaded, drop NAMED_OPPONENTS
+        # from the PARENT pool so pool.manifest() (broadcast to workers
+        # via sync_pool) carries only the frozen target(s). The worker
+        # seed pool below still includes NAMED_OPPONENTS — it needs some
+        # rule-based entry to sample from during the env.reset() call
+        # inside each spawn-worker's thunk, which fires before the
+        # parent's sync_pool broadcast arrives.
+        for name in list(NAMED_OPPONENTS.keys()):
+            pool.remove(name)
+        if len(pool) == 0:
+            raise ValueError(
+                "exclude_rule_based=True requires at least one "
+                "extra_opponent_ckpts entry; parent pool would be empty."
+            )
+        print(f"[train] exclude_rule_based: pool trimmed to {len(pool)} extras only")
 
     # AsyncVectorEnv runs one worker process per env (context="spawn" so
     # CUDA in the parent doesn't poison workers). The workers get a
@@ -661,6 +684,14 @@ def parse_args() -> RecurrentPPOConfig:
              f"({N_OPPONENT_IDS}) that matches the env's ID map. If both are "
              "passed, --n-opponents wins.",
     )
+    p.add_argument(
+        "--exclude-rule-based",
+        action="store_true",
+        help="After loading --extra-opponent-ckpts, drop NAMED_OPPONENTS "
+             "from the pool so training sees ONLY the extras. Used by the "
+             "exploiter (rl.exploiter) to train target-only; requires at "
+             "least one --extra-opponent-ckpts entry.",
+    )
     a = p.parse_args()
     cfg = RecurrentPPOConfig(
         total_timesteps=a.total_timesteps,
@@ -691,6 +722,7 @@ def parse_args() -> RecurrentPPOConfig:
         n_opponents=a.n_opponents if a.n_opponents > 0 else (
             N_OPPONENT_IDS if a.opp_embed else 0
         ),
+        exclude_rule_based=a.exclude_rule_based,
     )
     if a.run_name:
         cfg.run_name = a.run_name

--- a/rl/test_exploiter.py
+++ b/rl/test_exploiter.py
@@ -1,19 +1,26 @@
-"""Smoke tests for rl.exploiter.
+"""Tests for rl.exploiter.
 
-Validates the pool-monkey-patch approach: a tiny PPO recurrent run
-where the only opponent is a frozen policy — not NAMED_OPPONENTS —
-and training completes without the usual self-play opponent mix.
+Covers the bug that crashed E20 on launch: `train_exploiter` used to
+monkey-patch `OpponentPool` and inject a CUDA factory, which couldn't
+survive the AsyncVectorEnv spawn-pickle and raised BrokenPipeError
+during `_check_spaces`. New flow uses `cfg.exclude_rule_based=True`
++ `extra_opponent_ckpts=[target]`, which keeps CUDA refs in the
+parent and ships ckpt paths to workers.
 """
 
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
 
 import torch
 
 from rl.engine import NUM_ACTIONS
+from rl.exploiter import train_exploiter
+from rl.opponents import NAMED_OPPONENTS, OpponentPool, make_frozen_recurrent_opponent_factory
 from rl.policy import RecurrentActorCritic
+from rl.ppo_recurrent import RecurrentPPOConfig
 
 
 def _assert(cond, msg):
@@ -21,72 +28,126 @@ def _assert(cond, msg):
         raise AssertionError(msg)
 
 
-def test_exploiter_pool_factory_creates_main_only():
-    from rl.exploiter import make_exploiter_pool_factory
-
-    snap = RecurrentActorCritic(obs_dim=47, n_actions=NUM_ACTIONS, hidden=64).eval()
-    for p in snap.parameters():
+def _save_tiny_recurrent(path: str) -> None:
+    """Minimal recurrent .pt parseable by load_recurrent_policy."""
+    policy = RecurrentActorCritic(
+        obs_dim=47, n_actions=NUM_ACTIONS, hidden=32,
+    ).eval()
+    for p in policy.parameters():
         p.requires_grad_(False)
-    with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
-        torch.save(snap.state_dict(), f.name)
-        ckpt = f.name
-    try:
-        frozen, main_factory = make_exploiter_pool_factory(ckpt, device="cpu")
-        _assert(main_factory._is_factory is True, "main must be marked as a factory")
-        _assert(main_factory.ckpt_path == ckpt, "ckpt_path annotation must survive")
-        # Frozen must have no grad
-        for p in frozen.parameters():
-            _assert(not p.requires_grad, "frozen must not require grad")
-    finally:
-        os.unlink(ckpt)
-    print("ok  exploiter_pool_factory_creates_main_only")
+    torch.save(policy.state_dict(), path)
 
 
-def test_exploiter_monkeypatch_pool_is_main_only():
-    """Validate that the monkey-patch makes ppo_recurrent.OpponentPool
-    instantiate a pool of size 1 ('main') regardless of what
-    base_opponents is passed. This is how the exploiter ensures the
-    training loop never samples a rule-based opponent.
+def test_exclude_rule_based_drops_named_opponents():
+    """Drive the pool-prep phase of ppo_recurrent.train directly:
+    with exclude_rule_based=True (applied post-extras), the parent
+    pool contains ONLY extras. Guards against a regression where
+    NAMED_OPPONENTS leak into pool.manifest() (the async-broadcast
+    payload) alongside the frozen target.
     """
-    from rl.exploiter import make_exploiter_pool_factory
-    from rl.opponents import OpponentPool as RealPool
-    import rl.ppo_recurrent as ppo_mod
-
-    snap = RecurrentActorCritic(obs_dim=47, n_actions=NUM_ACTIONS, hidden=64).eval()
-    for p in snap.parameters():
-        p.requires_grad_(False)
     with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
-        torch.save(snap.state_dict(), f.name)
         ckpt = f.name
     try:
-        _, main_factory = make_exploiter_pool_factory(ckpt, device="cpu")
+        _save_tiny_recurrent(ckpt)
 
-        class _ExploiterPoolClass(RealPool):
-            def __init__(self, base_opponents=None):
-                super().__init__({"main": main_factory})
+        # Mirror ppo_recurrent's pool construction.
+        pool = OpponentPool(dict(NAMED_OPPONENTS))
+        _assert(len(pool) == len(NAMED_OPPONENTS),
+                f"initial pool size = {len(pool)}, expected {len(NAMED_OPPONENTS)}")
 
-        original = ppo_mod.OpponentPool
-        try:
-            ppo_mod.OpponentPool = _ExploiterPoolClass
-            # Instantiate the way ppo_recurrent.train would (passing
-            # NAMED_OPPONENTS — which the class ignores)
-            from rl.opponents import NAMED_OPPONENTS
-            pool = ppo_mod.OpponentPool(dict(NAMED_OPPONENTS))
-            _assert(len(pool) == 1, f"expected exploiter pool size 1, got {len(pool)}")
-            _assert("main" in pool.opponents, "'main' must be the sole opponent")
-            _assert(all(n != "random" for n in pool.opponents),
-                    "NAMED_OPPONENTS must not leak into exploiter pool")
-        finally:
-            ppo_mod.OpponentPool = original
+        state = torch.load(ckpt, map_location="cpu", weights_only=True)
+        obs_dim = int(state["obs_embed.0.weight"].shape[1])
+        hidden = int(state["gru.weight_ih_l0"].shape[0] // 3)
+        net = RecurrentActorCritic(obs_dim=obs_dim, n_actions=NUM_ACTIONS,
+                                   hidden=hidden).eval()
+        net.load_state_dict(state)
+        for p in net.parameters():
+            p.requires_grad_(False)
+        fac = make_frozen_recurrent_opponent_factory(net, device="cpu")
+        fac.ckpt_path = os.path.abspath(ckpt)
+        pool.add("extra:target", fac, weight=1.0)
+        _assert(len(pool) == len(NAMED_OPPONENTS) + 1,
+                "pool should contain NAMED_OPPONENTS + 1 extra pre-trim")
+
+        # exclude_rule_based trim.
+        for name in list(NAMED_OPPONENTS.keys()):
+            pool.remove(name)
+        _assert(len(pool) == 1,
+                f"after trim, pool should have 1 entry, got {len(pool)}")
+
+        manifest = pool.manifest()
+        _assert(len(manifest) == 1,
+                f"manifest must have only the extra, got {manifest}")
+        name, kind_spec, _w, _layout = manifest[0]
+        _assert(name == "extra:target", f"manifest name wrong: {name}")
+        _assert(kind_spec.startswith("ckpt:"),
+                f"manifest kind must be 'ckpt:<path>', got {kind_spec}")
     finally:
-        os.unlink(ckpt)
-    print("ok  exploiter_monkeypatch_pool_is_main_only")
+        try:
+            os.unlink(ckpt)
+        except OSError:
+            pass
+    print("ok  exclude_rule_based_drops_named_opponents")
+
+
+def test_train_exploiter_sets_flag():
+    """train_exploiter() must flip cfg.exclude_rule_based and call
+    ppo_recurrent_train with extra_opponent_ckpts=[ckpt]. We don't run
+    an actual training loop — we stub out the inner call and inspect
+    what was passed.
+    """
+    import rl.exploiter as exp_mod
+
+    calls: list[dict] = []
+
+    def fake_train(cfg, extra_opponent_ckpts=None):
+        calls.append({
+            "exclude_rule_based": cfg.exclude_rule_based,
+            "extras": list(extra_opponent_ckpts or []),
+        })
+        return object()
+
+    original = exp_mod.ppo_recurrent_train
+    try:
+        exp_mod.ppo_recurrent_train = fake_train
+        cfg = RecurrentPPOConfig(total_timesteps=100, num_envs=2, num_steps=16,
+                                 num_minibatches=2, hidden=32)
+        _assert(cfg.exclude_rule_based is False,
+                "cfg default should be exclude_rule_based=False")
+        train_exploiter("/tmp/fake.pt", cfg)
+    finally:
+        exp_mod.ppo_recurrent_train = original
+
+    _assert(len(calls) == 1, f"expected 1 train call, got {len(calls)}")
+    _assert(calls[0]["exclude_rule_based"] is True,
+            "train_exploiter must set exclude_rule_based=True on cfg")
+    _assert(calls[0]["extras"] == ["/tmp/fake.pt"],
+            f"extras must be [ckpt], got {calls[0]['extras']}")
+    print("ok  train_exploiter_sets_flag")
+
+
+def test_exclude_rule_based_requires_extras():
+    """If exclude_rule_based=True but no extras were loaded, the parent
+    pool would be empty — ppo_recurrent must reject this before spawn
+    to avoid an obscure failure later."""
+    # The validation happens inside ppo_recurrent.train. We call the
+    # relevant block directly to verify: pool ends up empty → ValueError.
+    pool = OpponentPool(dict(NAMED_OPPONENTS))
+    # No extras loaded, then exclude_rule_based trim.
+    for name in list(NAMED_OPPONENTS.keys()):
+        pool.remove(name)
+    _assert(len(pool) == 0,
+            f"with no extras + trim, pool should be empty, got {len(pool)}")
+    # Validation inside train() would raise here. This test documents
+    # the invariant; the explicit check lives in ppo_recurrent.train.
+    print("ok  exclude_rule_based_requires_extras (invariant documented)")
 
 
 def main() -> int:
     tests = [
-        test_exploiter_pool_factory_creates_main_only,
-        test_exploiter_monkeypatch_pool_is_main_only,
+        test_exclude_rule_based_drops_named_opponents,
+        test_train_exploiter_sets_flag,
+        test_exclude_rule_based_requires_extras,
     ]
     failures = 0
     for t in tests:
@@ -96,8 +157,8 @@ def main() -> int:
             print(f"FAIL {t.__name__}: {e}")
             failures += 1
     print(f"\n{len(tests) - failures}/{len(tests)} passed")
-    return 0 if failures == 0 else 1
+    return 1 if failures else 0
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Post-merge follow-up to PR #3. E20 exploiter crashed on launch with `BrokenPipeError` during `AsyncVectorEnv._check_spaces` because `exploiter.py` monkey-patched `OpponentPool` with a CUDA-bound factory that couldn't survive the spawn-pickle.

## What changed

- **`RecurrentPPOConfig.exclude_rule_based`** (new, default False). When True, `ppo_recurrent.train` drops `NAMED_OPPONENTS` from the parent pool after `extra_opponent_ckpts` load, so `pool.manifest()` (broadcast to async workers) carries only the extras. Worker seed pool still keeps `NAMED_OPPONENTS` briefly for spawn-safe env init.
- **`train_exploiter`** simplified from a class-level monkey-patch to a 2-line wrapper: set `cfg.exclude_rule_based = True`, call `ppo_recurrent_train(cfg, extra_opponent_ckpts=[target])`.
- **New CLI flag** `--exclude-rule-based` on `rl.ppo_recurrent`.

CUDA refs now live only in the parent process; workers receive ckpt paths and reload on CPU — the original async design.

## Test plan

- [x] 3 new tests in `rl/test_exploiter.py` (pool-manifest verification, flag plumbing, invariant check).
- [x] End-to-end smoke with `AsyncVectorEnv` (4 workers, 768 steps, pool=1 exploiter mode) — no BrokenPipeError, training completes, policy saved.
- [x] Full test suite: engine 30/30, opponents 30/30, env 15/15, policy 17/17, eval 2/2, exploiter 3/3 (97 total).
- [ ] Relaunch E20 on beeline once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes opponent-pool composition logic inside the recurrent PPO training path and adds a new flag that can alter training matchups; mistakes could silently change sampling behavior or break async worker sync.
> 
> **Overview**
> Fixes exploiter training under `AsyncVectorEnv` by removing the `OpponentPool` monkey-patch/CUDA factory injection and instead running through `ppo_recurrent.train` with `extra_opponent_ckpts=[target]` plus a new `RecurrentPPOConfig.exclude_rule_based` switch.
> 
> When `exclude_rule_based` is enabled, `ppo_recurrent.train` trims `NAMED_OPPONENTS` from the *parent* pool after extras load (and errors if this would leave the pool empty), so the manifest broadcast to workers contains only frozen target(s) and later snapshots. Adds a corresponding `--exclude-rule-based` CLI flag and updates `rl/test_exploiter.py` to assert pool trimming/manifest contents and that `train_exploiter` plumbs the flag and extras correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1b7e7be5637c0e05c8db3c600c7696e97aabe87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->