### PR TITLE
E19 post-fix re-eval: embedding is a per-class trade-off

### DIFF
--- a/rl/docs/experiment_log.md
+++ b/rl/docs/experiment_log.md
@@ -1638,6 +1638,53 @@ enough that eval numbers on the fixed engine are still
 meaningful — but any E19 "strategies" that depended on the
 exploit are now unreachable. No re-eval needed.
 
+### Post-fix re-eval (2026-04-21, after eval bug 055daf0)
+
+Bugbot 12ff10d6 flagged that `evaluate_recurrent_policy` never
+passed `opp_ids` into `act_stateful`, so E19's opponent embedding
+contributed 0 during all pre-merge evaluations — including the
+post-mortem table above. Re-ran 500-ep NAMED_OPPONENTS eval on
+the fixed code (`rl/eval.py` now threads `opp_id` from env info):
+
+| opponent        | Pre-fix E19-best | Post-fix E19-best | Δ     |
+|-----------------|------------------|-------------------|-------|
+| random          | 0.930            | **0.942**         | +1.2  |
+| aggressive      | 0.838            | **0.864**         | +2.6  |
+| conservative    | 0.766            | 0.770             | +0.4  |
+| strong_baseline | **0.690**        | 0.630             | −6.0  |
+| avg (rule)      | 0.806            | 0.802             | −0.4  |
+
+| opponent        | Pre-fix E19-final | Post-fix E19-final | Δ     |
+|-----------------|-------------------|--------------------|-------|
+| random          | 0.926             | **0.940**          | +1.4  |
+| aggressive      | 0.834             | **0.860**          | +2.6  |
+| conservative    | 0.764             | 0.770              | +0.6  |
+| strong_baseline | **0.674**         | 0.634              | −4.0  |
+| avg (rule)      | 0.800             | 0.801              | +0.1  |
+
+**What changed:** the embedding actually is doing something. With
+it active, E19 plays *differently* against each opponent class —
+noticeably better vs random/aggressive, worse vs strong_baseline.
+Average against rule-based is roughly unchanged. The +5pp H2H vs
+E18 (post-mortem's headline) is likely still directionally right
+but was measured on pre-fix data and needs a recurrent-aware H2H
+infra addition (round_robin's `play_match` only supports FF
+policies via `.act`; refactor for `act_stateful` + `opp_ids` is
+~30 min of work — deferred unless E20 shows a reason to care).
+
+**Refined verdict (post-fix):** E19 is a **trade-off win**, not
+a marginal one. The embedding specialises the policy per
+opponent — exploiting easier opponents harder and slightly
+under-exploiting strong_baseline. Average impact on rule-based
+is zero. The genuine lift we can't measure here is vs
+non-stationary recurrent snapshots (the pool during training) —
+that's where ids actually change. Don't expect the embedding to
+help vs fixed rule-based in future runs; keep it for the
+league-dynamics case.
+
+Re-eval raw JSON: `rl_runs/E19_opp_embed_s10/reeval_post_bugfix.json`
+(copied from beeline `~/e19_reeval_post_bugfix.json`).
+
 ## E20 — exploiter analysis (launched 2026-04-21 00:24 UTC)
 
 Diagnostic experiment picked from E19 post-mortem's candidate


### PR DESCRIPTION
## Summary

Docs-only update to the E19 post-mortem in `rl/docs/experiment_log.md`. After bugbot 12ff10d6 (merged in PR #3 as commit `055daf0`) fixed `evaluate_recurrent_policy` to thread `opp_ids` into `act_stateful`, re-ran the 500-ep NAMED_OPPONENTS eval on beeline for E19-best (u=2160) and E19-final (u=2440).

## Key finding

The opponent embedding actually IS doing work, just not the work I assumed:

| opponent        | Pre-fix E19-best | Post-fix E19-best | Δ     |
|-----------------|------------------|-------------------|-------|
| random          | 0.930            | **0.942**         | +1.2  |
| aggressive      | 0.838            | **0.864**         | +2.6  |
| conservative    | 0.766            | 0.770             | +0.4  |
| strong_baseline | **0.690**        | 0.630             | −6.0  |
| avg (rule)      | 0.806            | 0.802             | −0.4  |

Embedding specialises the policy **per opponent class**, so gains on easy opponents trade off against losses on `strong_baseline`. Average is flat.

## What's NOT in this PR

- H2H E19-best vs E18-final. The current `round_robin.play_match` only supports FF policies (via `.act()`); a recurrent-aware H2H with `act_stateful + opp_ids` for both sides would be ~30 min of work. Deferred until E20 results come in.

## Test plan

- [x] Re-eval ran clean on beeline (CPU), both checkpoints loaded, produced sensible numbers.
- [x] JSON persisted at `~/e19_reeval_post_bugfix.json` on beeline.
- [x] No code changes — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change updating reported E19 evaluation numbers and conclusions after an evaluation bugfix; no runtime code paths are modified.
> 
> **Overview**
> Adds a new **post-bugfix re-evaluation** section to the E19 post-mortem in `rl/docs/experiment_log.md`, re-running 500-episode `NAMED_OPPONENTS` evals after `evaluate_recurrent_policy` began correctly threading `opp_id`/`opp_ids` into `act_stateful`.
> 
> Updates the reported win-rate tables for E19-best and E19-final and revises the conclusion to a **per-opponent trade-off** (improved vs `random`/`aggressive`, worse vs `strong_baseline`, roughly flat on average), with a note that recurrent-aware head-to-head infra would be needed to re-measure the E18 H2H claim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c218e77b49151ccaca7b244798117a96936916c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->