### PR TITLE
Docker deploy: CPU torch, proxy support, compose template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Copy to `.env` and fill in. `.env` is gitignored.
+#
+# Telegram bot token from @BotFather. Required.
+BOT_TOKEN=
+
+# Optional HTTPS proxy if the host can't reach api.telegram.org directly
+# (e.g. the Russian ISP filter). Same URL format as other bots on the
+# same server use: `https://user:pass@host:port`. Leave empty to disable.
+BOT_PROXY=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,25 @@
+# Buckshot Roulette Telegram bot — multiplayer + /ai single-player.
+#
+# The /ai mode needs BOTH `app/` (the bot) AND `rl/` (the trained policy's
+# engine and actor-critic — `app/ai/__init__.py` splices the parent of
+# `app/` into sys.path at import time so `from rl.engine import ...`
+# resolves inside the container).
 FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY app/requirements.txt /app/requirements.txt
+# Two-layer dep install:
+#  1. CPU-only torch wheel. E19 inference is <10 ms per call on CPU —
+#     pulling the CUDA wheel would add ~2 GB to the image for nothing.
+#  2. The rest of requirements.txt.
+COPY app/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu "torch>=2.1,<3" \
+ && pip install --no-cache-dir -r /tmp/requirements.txt
 
-RUN pip install --no-cache-dir -r /app/requirements.txt
-
+# Copy the bot AND the RL package. Layout mirrors the repo root so
+# `_REPO_ROOT = parent of app/` in `app/ai/__init__.py` resolves to `/`
+# and `/rl` becomes importable.
 COPY app /app
+COPY rl  /rl
 
 CMD ["python", "main.py"]

--- a/app/main.py
+++ b/app/main.py
@@ -21,7 +21,24 @@ async def main() -> None:
         handlers=[logging.StreamHandler()],
         datefmt="%d.%m.%Y %H:%M:%S",
     )
-    bot = Bot(token=config.bot_token.get_secret_value())
+    logger = logging.getLogger(__name__)
+
+    # Optional HTTPS proxy for hosts that can't reach api.telegram.org
+    # directly. compose.yml passes `BOT_PROXY` through as `HTTPS_PROXY`;
+    # if it's unset we fall back to aiogram's default aiohttp transport.
+    # httpx is used (see utils/httpx_session) because aiohttp's handling
+    # of TLS-tunnel proxies is inconsistent.
+    proxy_url = os.getenv("HTTPS_PROXY") or None
+    session = None
+    if proxy_url:
+        from utils.httpx_session import HttpxSession
+        session = HttpxSession(proxy=proxy_url)
+        # Strip credentials before logging — the proxy URL typically
+        # carries `user:password@host:port`.
+        host_tail = proxy_url.split("@")[-1] if "@" in proxy_url else proxy_url
+        logger.info("HTTPS proxy enabled: %s", host_tail)
+
+    bot = Bot(token=config.bot_token.get_secret_value(), session=session)
     dp = Dispatcher(name='main', storage=STORAGE)
     # dp.message.middleware(Debug())
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -7,3 +7,7 @@ numpy==1.24.3
 #   pip install torch --index-url https://download.pytorch.org/whl/cpu
 # if you want to avoid pulling CUDA dependencies on the bot host.
 torch>=2.1,<3
+# Optional — only imported when HTTPS_PROXY is set (see utils/httpx_session).
+# aiogram's default aiohttp transport handles TLS-tunnel proxies
+# inconsistently; httpx is used as a drop-in for the proxied path.
+httpx>=0.27,<1

--- a/app/utils/httpx_session.py
+++ b/app/utils/httpx_session.py
@@ -62,10 +62,15 @@ class HttpxSession(BaseSession):
         files_dict: dict[str, "InputFile"] = {}
 
         for key, value in method.model_dump(warnings=False).items():
-            value = self.prepare_value(value, bot=bot, files=files_dict)
-            if not value:
+            # Match aiogram's upstream `AiohttpSession.make_request`: skip
+            # only unset (None) fields, not any falsy value. The previous
+            # `if not value` here would have silently dropped legitimate
+            # `""`, `0`, and `False` parameters after `prepare_value`
+            # stringified them — e.g. an empty caption or a 0-valued
+            # message_thread_id would never make it to Telegram.
+            if value is None:
                 continue
-            data[key] = value
+            data[key] = self.prepare_value(value, bot=bot, files=files_dict)
 
         httpx_files: list[tuple[str, tuple[str, bytes]]] = []
         for key, input_file in files_dict.items():

--- a/app/utils/httpx_session.py
+++ b/app/utils/httpx_session.py
@@ -1,0 +1,116 @@
+"""aiogram session backed by httpx with first-class HTTPS-proxy support.
+
+aiohttp (aiogram's default transport) handles TLS-tunnel proxies
+inconsistently across versions — connections either silently hang or
+give cryptic ``ClientProxyConnectionError``s. httpx supports the same
+`https://user:pass@host:port` URL scheme and just works. This module
+ports the session wrapper from the neighbouring rambirds bot (same
+operator's Telegram stack) so both bots share the same transport when
+api.telegram.org isn't directly reachable.
+
+Used only when the ``HTTPS_PROXY`` environment variable is set; see
+``main.py`` for wiring.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, Any, cast
+
+import httpx
+
+from aiogram.exceptions import TelegramNetworkError
+from aiogram.methods.base import TelegramType
+from aiogram.client.session.base import BaseSession
+
+if TYPE_CHECKING:
+    from aiogram.client.bot import Bot
+    from aiogram.methods import TelegramMethod
+    from aiogram.types import InputFile
+
+
+class HttpxSession(BaseSession):
+    """``BaseSession`` backed by ``httpx.AsyncClient`` with proxy support."""
+
+    def __init__(self, proxy: str | None = None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._proxy = proxy
+        self._client: httpx.AsyncClient | None = None
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(proxy=self._proxy)
+        return self._client
+
+    async def _collect_file_bytes(self, input_file: "InputFile", bot: "Bot") -> bytes:
+        chunks = []
+        async for chunk in input_file.read(bot):
+            chunks.append(chunk)
+        return b"".join(chunks)
+
+    async def make_request(
+        self,
+        bot: "Bot",
+        method: "TelegramMethod[TelegramType]",
+        timeout: int | None = None,
+    ) -> TelegramType:
+        client = await self._get_client()
+        url = self.api.api_url(token=bot.token, method=method.__api_method__)
+
+        data: dict[str, Any] = {}
+        files_dict: dict[str, "InputFile"] = {}
+
+        for key, value in method.model_dump(warnings=False).items():
+            value = self.prepare_value(value, bot=bot, files=files_dict)
+            if not value:
+                continue
+            data[key] = value
+
+        httpx_files: list[tuple[str, tuple[str, bytes]]] = []
+        for key, input_file in files_dict.items():
+            file_bytes = await self._collect_file_bytes(input_file, bot)
+            httpx_files.append((key, (input_file.filename or key, file_bytes)))
+
+        req_timeout = self.timeout if timeout is None else timeout
+
+        try:
+            resp = await client.post(
+                url,
+                data=data,
+                files=httpx_files or None,
+                timeout=req_timeout,
+            )
+        except httpx.TimeoutException as e:
+            raise TelegramNetworkError(method=method, message="Request timeout error") from e
+        except httpx.HTTPError as e:
+            raise TelegramNetworkError(method=method, message=f"{type(e).__name__}: {e}") from e
+
+        response = self.check_response(
+            bot=bot,
+            method=method,
+            status_code=resp.status_code,
+            content=resp.text,
+        )
+        return cast(TelegramType, response.result)
+
+    async def stream_content(
+        self,
+        url: str,
+        headers: dict[str, Any] | None = None,
+        timeout: int = 30,
+        chunk_size: int = 65536,
+        raise_for_status: bool = True,
+    ) -> AsyncGenerator[bytes, None]:
+        client = await self._get_client()
+        async with client.stream(
+            "GET", url, headers=headers or {}, timeout=timeout,
+        ) as resp:
+            if raise_for_status:
+                resp.raise_for_status()
+            async for chunk in resp.aiter_bytes(chunk_size):
+                yield chunk
+
+    async def close(self) -> None:
+        if self._client is not None and not self._client.is_closed:
+            await self._client.aclose()

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,38 @@
+# Compose file for deploying the Telegram bot on a docker host.
+# Convention matches the neighbouring bots on the same server (rambirds,
+# voice2text) so operators can run `docker compose up -d` without having
+# to re-read each project.
+#
+# Required: a `.env` next to this file containing at minimum `BOT_TOKEN`.
+# See `.env.example` for the full list of variables.
+
+services:
+  bot:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: buckshot-roulette:latest
+    container_name: buckshot_bot
+    restart: always
+    env_file:
+      - .env
+    environment:
+      # Pass the proxy through as HTTPS_PROXY — `app/main.py` reads this
+      # and wires up an httpx-backed aiogram session when it's set.
+      # Empty default keeps the variable defined-but-empty so compose
+      # doesn't warn about an unset interpolation.
+      - HTTPS_PROXY=${BOT_PROXY:-}
+    volumes:
+      # Persist the rotating log file so restarts don't lose history.
+      - ./log:/app/log
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+    labels:
+      # Set to `true` to let the host's watchtower auto-pull new images.
+      # Off by default — this compose file builds locally, so there's
+      # nothing for watchtower to pull unless you flip to a registry
+      # workflow.
+      - com.centurylinklabs.watchtower.enable=false

--- a/rl/__init__.py
+++ b/rl/__init__.py
@@ -1,5 +1,14 @@
 from .engine import Action, BuckshotEngine, GameState, Item, NUM_ACTIONS, NUM_ITEMS
-from .env import BuckshotAECEnv
+
+# `BuckshotAECEnv` pulls gymnasium + pettingzoo (training-only deps).
+# Keep the import lazy so inference-only consumers — notably the Telegram
+# bot at `app/` — don't have to ship the full training stack. Training
+# code can still do `from rl.env import BuckshotAECEnv` directly to
+# trigger an ImportError if the deps are actually missing.
+try:
+    from .env import BuckshotAECEnv  # noqa: F401
+except ImportError:  # pragma: no cover
+    BuckshotAECEnv = None
 
 __all__ = [
     "Action",


### PR DESCRIPTION
## Summary

Makes the bot reproducibly deployable via `docker compose up -d`:

- **Dockerfile** now installs CPU-only torch (~1.5 GB saved vs default CUDA wheel) and copies `rl/` alongside `app/` so /ai mode can find the engine.
- **`rl/__init__.py`** no longer eagerly imports `BuckshotAECEnv` (training-only, pulls gymnasium). Wrapping the import in `try/except` lets inference consumers skip the training stack.
- **`app/utils/httpx_session.py`** (new) — httpx-backed `BaseSession` with proper `proxy=` support, ported from the rambirds bot on the same server because aiogram's aiohttp path is flaky with TLS-tunnel proxies.
- **`app/main.py`** reads `HTTPS_PROXY` and wires the session when set. Credentials stripped from the log line.
- **`compose.yml` + `.env.example`** at repo root — deploy template matching neighbouring-bot conventions (rambirds, voice2text).

## Test plan

- [x] Smoke tests 9/9 still pass (proxy path is import-lazy)
- [x] `docker compose build` succeeds on the target host
- [x] `docker run --rm buckshot-roulette:latest python test_ai_smoke.py` → 9/9
- [ ] After merge: `git pull && docker compose up -d` on the target host, watch `docker compose logs -f bot` for `"Start polling"` and /start round-trip via Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes runtime networking via an alternative aiogram session and adds deployment/container packaging tweaks that could affect bot connectivity and `/ai` imports in production.
> 
> **Overview**
> Makes the bot reproducibly deployable via Docker by adding `compose.yml` and `.env.example`, and updating the `Dockerfile` to install a CPU-only `torch` wheel and bundle `rl/` alongside `app/` so `/ai` mode can import the RL engine.
> 
> Adds optional HTTPS proxy support: `app/main.py` wires an httpx-backed aiogram `BaseSession` when `HTTPS_PROXY` is set (with credential-safe logging), backed by new `utils/httpx_session.py` and an optional `httpx` dependency.
> 
> Adjusts `rl/__init__.py` to lazily import `BuckshotAECEnv` behind `try/except` so inference consumers don’t require training-only dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da49de434b949997e0d1627bff74c4af11ce7b69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->