### PR TITLE
Remove committed app/.env placeholder (breaks proxied deploy)

### DIFF
--- a/app/.env
+++ b/app/.env
@@ -1,1 +1,0 @@
-bot_token=


### PR DESCRIPTION
## Summary

`app/.env` had a single line `bot_token=` (empty value) committed from early development. Inside the Docker container, `load_dotenv()` at the top of `config.py` re-reads that file and sets `os.environ['bot_token'] = ''`. pydantic-settings is case-insensitive by default, and in the env-var lookup it hits the lowercase empty `bot_token` before the real `BOT_TOKEN` passed via compose's `env_file`, so `Bot(token=...)` sees an empty string and crashes with `TokenValidationError: Token is invalid!`.

The file had no purpose (`.env` is already in `.gitignore` at any depth), so deleting it lets local dev keep their own uncommitted `app/.env` without a placeholder ever reaching a production image again.

## Test plan

- [x] After removing the file, a container started with `BOT_TOKEN=<real token>` via `env_file` will pick up the correct token instead of the empty placeholder
- [ ] After merge: `git pull && docker compose up -d --build` on the target host and verify `"Start polling"` in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change that only removes a committed `.env` placeholder; impact is limited to environment-variable resolution at startup and should prevent accidental empty `bot_token` overrides in container builds.
> 
> **Overview**
> Removes the committed `app/.env` placeholder (the empty `bot_token=` entry) so container builds no longer load an empty token from the image.
> 
> This prevents `.env` in the repo from overriding real `BOT_TOKEN` values provided via deployment `env_file`/environment variables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c75179e866103dc92f35218f7dfeae45e443206d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->