### PR TITLE
Send winner sticker when configured

### DIFF
--- a/app/handlers/echo.py
+++ b/app/handlers/echo.py
@@ -11,14 +11,3 @@ async def cmd_start(message: Message):
     await message.answer(
         text=str(message),
     )
-
-
-@router.message(lambda message: message.sticker is not None)
-async def show_sticker_id(message: Message):
-    await message.answer(
-        text=(
-            "Sticker file_id:\n"
-            f"{message.sticker.file_id}\n\n"
-            "Вставь это значение в `WIN_STICKER_ID` в `app/handlers/rooms_manager.py`."
-        ),
-    )

--- a/app/handlers/echo.py
+++ b/app/handlers/echo.py
@@ -18,8 +18,7 @@ async def show_sticker_id(message: Message):
     await message.answer(
         text=(
             "Sticker file_id:\n"
-            f"`{message.sticker.file_id}`\n\n"
+            f"{message.sticker.file_id}\n\n"
             "Вставь это значение в `WIN_STICKER_ID` в `app/handlers/rooms_manager.py`."
         ),
-        parse_mode="Markdown",
     )

--- a/app/handlers/echo.py
+++ b/app/handlers/echo.py
@@ -1,4 +1,4 @@
-from aiogram import Router, F
+from aiogram import Router
 from aiogram.filters import Command
 from aiogram.types import Message
 
@@ -10,4 +10,16 @@ router = Router()
 async def cmd_start(message: Message):
     await message.answer(
         text=str(message),
+    )
+
+
+@router.message(lambda message: message.sticker is not None)
+async def show_sticker_id(message: Message):
+    await message.answer(
+        text=(
+            "Sticker file_id:\n"
+            f"`{message.sticker.file_id}`\n\n"
+            "Вставь это значение в `WIN_STICKER_ID` в `app/handlers/rooms_manager.py`."
+        ),
+        parse_mode="Markdown",
     )

--- a/app/handlers/rooms_manager.py
+++ b/app/handlers/rooms_manager.py
@@ -1,5 +1,6 @@
 import random
 import re
+import logging
 from aiogram import F, Bot, Router, types
 from aiogram.filters import Command
 from aiogram.types import Message
@@ -21,6 +22,8 @@ from utils.edit_message_with_delay import edit_message
 
 router = Router()
 MANAGER = RoomsManager()
+logger = logging.getLogger(__name__)
+WIN_STICKER_ID = None  # Paste sticker file_id here, for example: "CAACAgIAAxkBA..."
 
 
 @router.message(Command("find"), StateFilter(None))
@@ -281,6 +284,13 @@ async def send_game_end_message(
     bot: Bot, room, keyboard_die, keyboard_win, loser: Player, winner: Player
 ):
     await bot.send_message(loser.data.chat_id, "⚰️You died", reply_markup=keyboard_die)
+
+    if WIN_STICKER_ID:
+        try:
+            await bot.send_sticker(winner.data.chat_id, sticker=WIN_STICKER_ID)
+        except Exception:
+            logger.exception("Failed to send winner sticker to chat_id=%s", winner.data.chat_id)
+
     await bot.send_message(
         winner.data.chat_id, "💼Congratulations, you've won!", reply_markup=keyboard_win
     )

--- a/app/handlers/rooms_manager.py
+++ b/app/handlers/rooms_manager.py
@@ -23,7 +23,7 @@ from utils.edit_message_with_delay import edit_message
 router = Router()
 MANAGER = RoomsManager()
 logger = logging.getLogger(__name__)
-WIN_STICKER_ID = None  # Paste sticker file_id here, for example: "CAACAgIAAxkBA..."
+WIN_STICKER_ID = "CAACAgIAAxkBAAEBuf1p6kaACU2hkSZ0LlN9J_XaRVPWOwACSTEAAoTfaEtmyI9fpwx3RzsE"
 
 
 @router.message(Command("find"), StateFilter(None))


### PR DESCRIPTION
## Summary
- send a configured sticker to the winning player before the victory message
- add a sticker handler that replies with the incoming sticker file_id for easy setup
- keep the feature opt-in via a local WIN_STICKER_ID constant in the game handler

## Testing
- python3 -m compileall /Users/macbook/buckshot-roulette/app

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional `bot.send_sticker` call on game completion and logs failures without affecting core game flow.
> 
> **Overview**
> Sends an *optional* configured winner sticker (`WIN_STICKER_ID`) to the winning player before the victory message when a game ends, with exception handling and logging to avoid breaking end-of-game cleanup.
> 
> Also removes an unused `aiogram.F` import from `echo.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf6aa0c2155752aee338e40e72d49b5bc09785b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->